### PR TITLE
Yekaterinburg instead of Sverdlovsk

### DIFF
--- a/localisation/english/state_names_l_english.yml
+++ b/localisation/english/state_names_l_english.yml
@@ -663,7 +663,7 @@
  STATE_650:0 "Attu Island"
  STATE_651:0 "Ufa"
  STATE_652:0 "Orenburg"
- STATE_653:0 "Sverdlovsk"
+ STATE_653:0 "Yekaterinburg"
  STATE_654:1 "Oyrot Region"
  STATE_655:0 "North Sakhalin"
  STATE_656:0 "Kuwait"


### PR DESCRIPTION
Change Sverdlovsk state name to Yekaterinburg